### PR TITLE
added missing #include

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 #include <bluetooth/hci.h>
 #include <zephyr/types.h>
+#include <random/rand32.h>
 
 #include "exposure-notification.h"
 #include "covid_types.h"


### PR DESCRIPTION
random/rand32.h is needed for sys_csrand_get()