### PR TITLE
WIP: Record Binary Search Refactoring

### DIFF
--- a/src/ens/sequencenumber.c
+++ b/src/ens/sequencenumber.c
@@ -7,7 +7,7 @@
  */
 #define GET_MASKED_SN(x) (x & SN_MASK)
 
-int sn_equal(record_sequence_number_t a, record_sequence_number_t b) {
+bool sn_equal(record_sequence_number_t a, record_sequence_number_t b) {
     return GET_MASKED_SN(a) == GET_MASKED_SN(b);
 }
 
@@ -15,8 +15,20 @@ record_sequence_number_t sn_increment(record_sequence_number_t sn) {
     return GET_MASKED_SN(++sn);
 }
 
+record_sequence_number_t sn_decrement(record_sequence_number_t sn) {
+    if (sn > 0) {
+        return GET_MASKED_SN((sn-1));
+    } else {
+        return SN_MASK;
+    }
+}
+
 record_sequence_number_t sn_increment_by(record_sequence_number_t sn, uint32_t amount) {
     return GET_MASKED_SN((sn + amount));
+}
+
+record_sequence_number_t sn_decrement_by(record_sequence_number_t sn, uint32_t amount) {
+    return sn_increment_by(sn, (SN_MASK+1)-amount);
 }
 
 record_sequence_number_t sn_get_middle_sn(record_sequence_number_t older, record_sequence_number_t newer) {

--- a/src/ens/sequencenumber.c
+++ b/src/ens/sequencenumber.c
@@ -27,10 +27,6 @@ record_sequence_number_t sn_increment_by(record_sequence_number_t sn, uint32_t a
     return GET_MASKED_SN((sn + amount));
 }
 
-record_sequence_number_t sn_decrement_by(record_sequence_number_t sn, uint32_t amount) {
-    return sn_increment_by(sn, (SN_MASK+1)-amount);
-}
-
 record_sequence_number_t sn_get_middle_sn(record_sequence_number_t older, record_sequence_number_t newer) {
     if (older <= newer) {
         return GET_MASKED_SN(((older + newer) / 2));

--- a/src/ens/sequencenumber.h
+++ b/src/ens/sequencenumber.h
@@ -2,6 +2,7 @@
 #define SEQUENCENUMBER_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef uint32_t record_sequence_number_t;
 
@@ -12,7 +13,7 @@ typedef uint32_t record_sequence_number_t;
  * @param b second sequence number
  * @return 1, if sequence numbers are equal, 0 otherwise.
  */
-int sn_equal(record_sequence_number_t a, record_sequence_number_t b);
+bool sn_equal(record_sequence_number_t a, record_sequence_number_t b);
 
 /**
  * Increment the given sequence number. Wraps around, if 2^24 is reached.
@@ -21,6 +22,14 @@ int sn_equal(record_sequence_number_t a, record_sequence_number_t b);
  * @return the incremented sequence number
  */
 record_sequence_number_t sn_increment(record_sequence_number_t sn);
+
+/**
+ * Decrement the given sequence number. Wraps around, if 0 is reached.
+ *
+ * @param sn sequence number to increment
+ * @return the incremented sequence number
+ */
+record_sequence_number_t sn_decrement(record_sequence_number_t sn);
 
 /**
  * Increment the given sequence number by a given amount.

--- a/src/ens/storage.h
+++ b/src/ens/storage.h
@@ -68,4 +68,7 @@ record_sequence_number_t get_oldest_sequence_number();
  */
 uint32_t get_num_records();
 
+
+int get_sequence_number_interval(record_sequence_number_t* oldest, record_sequence_number_t *latest);
+
 #endif


### PR DESCRIPTION
This PR should eliminate a few potential issues with the current binary search.
1. Correct handling of sn_increment_by (as it only supports unsigned ints)
2. Add method to get a reliable start and end sequence numbers using storage's lock mechanism
3. Guarantee that the min and max (e.g. for start and end) will really result in the first and last of the entries with that timestamps. 

Todos:
- [ ] Add tests (by sequence / by timerange, in case of empty records, full records, missing records etc.)