### PR TITLE
Set specific Zephyr version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = nrf52840_dk
 
 [env:nrf52840_dk]
-platform = nordicnrf52
+platform = nordicnrf52@7.0.0
 board = nrf52840_dk
 framework = zephyr
 monitor_speed = 115200


### PR DESCRIPTION
Set a specific Zephyr version by specifying a concrete platform version, which requires Zephyr v2.5.0.

Closes #18 